### PR TITLE
v0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # RawLinux
 
-Barebones Linux custom image, based on 6.14.0-rc4 kernel - smallest possible "distribution".
+Barebones Linux custom image, based on 6.14.0-rc2 kernel - smallest possible "distribution".
 
 Everything redistributed in this project can be found in [sources](sources.txt) file.
 
 ### How to run it
 
+Grab the latest [release](https://github.com/JakubBialoskorski/RawLinux/releases)
 Unzip `disk.img.7z` file.
 
 Make sure you have `qemu` installed: 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Launch it with `qemu-system-x86_64 disk.img` .
 
 [x] enable networking (ethernet)
 
+[x] add compiler (self-sustained system)
+
 [ ] document system libs and their purpose
 
 [ ] configure systemd

--- a/sources.txt
+++ b/sources.txt
@@ -2,7 +2,7 @@ Linux Kernel: https://github.com/torvalds/linux
 Bash: https://git.savannah.gnu.org/git/bash
 coreutils: https://github.com/coreutils/coreutils
 util-Linux: https://github.com/util-linux/util-linux
-glibc: https://sourceware.org/git/glibc
+glibc: https://ftp.gnu.org/gnu/glibc
 Ncurses: https://ftp.gnu.org/gnu/ncurses
 iproute2: https://github.com/iproute2/iproute2
 elfutils: git://sourceware.org/git/elfutils
@@ -13,3 +13,25 @@ wget: https://ftp.gnu.org/gnu/wget
 pcre2: https://github.com/PCRE2Project/pcre2
 OpenSSL: https://github.com/openssl/openssl
 DNSMasq: git://thekelleys.org.uk/dnsmasq
+GCC & libstddc++: https://ftp.gnu.org/gnu/gcc
+make: https://ftp.gnu.org/gnu/make
+tar: https://ftp.gnu.org/gnu/tar
+gzip: https://ftp.gnu.org/gnu/gzip
+sed: https://ftp.gnu.org/gnu/sed
+grep: https://ftp.gnu.org/gnu/grep
+awk: https://ftp.gnu.org/gnu/gawk
+binutils: https://sourceware.org/pub/binutils/releases
+xz: https://github.com/tukaani-project/xz/releases
+diffutils: https://ftp.gnu.org/gnu/diffutils
+m4: https://ftp.gnu.org/gnu/m4
+bison: https://ftp.gnu.org/gnu/bison
+bzip2: https://sourceware.org/pub/bzip2
+FLEX: https://github.com/westes/flex/releases
+findutils: https://ftp.gnu.org/gnu/findutils
+Perl: https://cpan.org/src/5.0
+autoconf: https://ftp.gnu.org/gnu/autoconf
+Texinfo: https://ftp.gnu.org/gnu/texinfo
+BC: https://ftp.gnu.org/gnu/bc
+curl: https://github.com/curl/curl/releases
+git: https://github.com/git/git/archive/refs/tags
+strace: https://github.com/strace/strace/releases


### PR DESCRIPTION
Added gcc, make, tar, gzip, sed, grep, awk, binutils, xz, diffutils, m4, bison, bzip2, flex, findutils, perl, autoconf, texinfo, bc, curl, git, strace.
System is able to compile libs on it's own, from within, along with new kernels.
Kernel version is set to 6.14.0-rc2 (for now).

Due to increased image size, all releases will be handled by the "releases" section.