### PR TITLE
[fix] Typos and improved descriptions in docs

### DIFF
--- a/docs/libs-purpose.md
+++ b/docs/libs-purpose.md
@@ -4,17 +4,17 @@ Bash: to have a basic shell.
 
 coreutils: to be able to run `cat`, `rm`, `cp` etc.
 
-util-Linux: bunch of tools like `mount` .
+util-linux: bunch of tools like `mount` .
 
 glibc: contains lib loader `ld-linux`, allows to use dynamic libraries.
 
-Ncurses: allows Bash to work (well, not only it).
+ncurses: terminal library, required by Bash and other terminal applications.
 
 iproute2: default network tool, allows connection to the Internet.
 
 elfutils: provides `libelf` and elf editing tools.
 
-libcap: handles priviledge and permissions.
+libcap: handles privilege and permissions.
 
 zlib: compression tool, provides `libz`.
 
@@ -26,9 +26,9 @@ pcre2: tool for regex pattern matching.
 
 OpenSSL: library for SSL, TLS, HTTPS etc.
 
-DNSMasq: small DNS server from more civilized times (before systemd).
+dnsmasq: lightweight DNS/DHCP server.
 
-GCC & libstddc++: basic GNU compiler and it's C++ libs.
+GCC & libstdc++: basic GNU compiler and it's C++ libs.
 
 make: tool to build from sources.
 
@@ -40,11 +40,11 @@ sed: stream editor.
 
 grep: to catch strings.
 
-awk: dependency for Perl.
+awk: text processing tool, also needed by Perl.
 
 binutils: used with `make`.
 
-xz: to test compiler inside the distro.
+xz: compression tool, used to verify the compiler.
 
 diffutils: provides `diff` and `cmp`.
 
@@ -54,17 +54,17 @@ bison: needed by the kernel and other GNU software.
 
 bzip2: to complement `tar` and `gzip`.
 
-FLEX: Fast Lexical Analyzer, needed by the kernel.
+flex: Fast Lexical Analyzer, needed by the kernel.
 
 findutils: provides `find`.
 
-Perl: needed everywhere + `curl`.
+Perl: needed by many tools, including `curl`.
 
 autoconf: needed by `git`.
 
 Texinfo: required by `bc`, which is a dependency for the kernel.
 
-BC: needed to compile the kernel itself.
+bc: needed to compile the kernel itself.
 
 curl: tool for downloading stuff.
 

--- a/docs/sources.txt
+++ b/docs/sources.txt
@@ -1,9 +1,9 @@
 Linux Kernel: https://github.com/torvalds/linux
 Bash: https://git.savannah.gnu.org/git/bash
 coreutils: https://github.com/coreutils/coreutils
-util-Linux: https://github.com/util-linux/util-linux
+util-linux: https://github.com/util-linux/util-linux
 glibc: https://ftp.gnu.org/gnu/glibc
-Ncurses: https://ftp.gnu.org/gnu/ncurses
+ncurses: https://ftp.gnu.org/gnu/ncurses
 iproute2: https://github.com/iproute2/iproute2
 elfutils: git://sourceware.org/git/elfutils
 libcap: https://git.kernel.org/pub/scm/libs/libcap
@@ -12,8 +12,8 @@ zstd: https://github.com/facebook/zstd
 wget: https://ftp.gnu.org/gnu/wget
 pcre2: https://github.com/PCRE2Project/pcre2
 OpenSSL: https://github.com/openssl/openssl
-DNSMasq: git://thekelleys.org.uk/dnsmasq
-GCC & libstddc++: https://ftp.gnu.org/gnu/gcc
+dnsmasq: git://thekelleys.org.uk/dnsmasq
+GCC & libstdc++: https://ftp.gnu.org/gnu/gcc
 make: https://ftp.gnu.org/gnu/make
 tar: https://ftp.gnu.org/gnu/tar
 gzip: https://ftp.gnu.org/gnu/gzip
@@ -26,12 +26,12 @@ diffutils: https://ftp.gnu.org/gnu/diffutils
 m4: https://ftp.gnu.org/gnu/m4
 bison: https://ftp.gnu.org/gnu/bison
 bzip2: https://sourceware.org/pub/bzip2
-FLEX: https://github.com/westes/flex/releases
+flex: https://github.com/westes/flex/releases
 findutils: https://ftp.gnu.org/gnu/findutils
 Perl: https://cpan.org/src/5.0
 autoconf: https://ftp.gnu.org/gnu/autoconf
 Texinfo: https://ftp.gnu.org/gnu/texinfo
-BC: https://ftp.gnu.org/gnu/bc
+bc: https://ftp.gnu.org/gnu/bc
 curl: https://github.com/curl/curl/releases
 git: https://github.com/git/git/archive/refs/tags
 strace: https://github.com/strace/strace/releases


### PR DESCRIPTION
Fixed typos (`libstddc++` → `libstdc++`, `priviledge` → `privilege`), corrected casing to match official project names (`util-Linux` → `util-linux`, `Ncurses` → `ncurses`, `DNSMasq` → `dnsmasq`, `FLEX` → `flex`, `BC` → `bc`), and improved a few unclear descriptions in `libs-purpose.md`.